### PR TITLE
Update CustomShortcuts.uplugin to prevent errors when compiling in VS…

### DIFF
--- a/CustomShortcuts.uplugin
+++ b/CustomShortcuts.uplugin
@@ -19,8 +19,8 @@
 	],
 	"Plugins": [
 		{
-			"Name": "EditorScriptingTools",
-			"Enabled": True
+			"Name": "EditorScriptingUtilities",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
Hey there! When pulling latest & trying to compile in a 5.0 project in VS 2022, I got the following errors:

```
Severity	Code	Description	Project	File	Line	Suppression State
Error		Unhandled exception: EpicGames.Core.JsonParseException: Unable to parse C:\Users\hippo\Documents\Unreal Projects\CustomKeybinds\Plugins\CustomShortcuts\CustomShortcuts.uplugin: 'T' is an invalid start of a value. LineNumber: 22 | BytePositionInLine: 14.	CustomKeybinds	C:\Users\hippo\Documents\Unreal Projects\CustomKeybinds\Intermediate\ProjectFiles\UnrealBuildTool	1	

Error	MSB3073	The command ""C:\Program Files\Epic Games\UE_5.0\Engine\Build\BatchFiles\Build.bat" CustomKeybindsEditor Win64 Development -Project="C:\Users\hippo\Documents\Unreal Projects\CustomKeybinds\CustomKeybinds.uproject" -WaitMutex -FromMsBuild" exited with code 6.	CustomKeybinds	C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.MakeFile.Targets	44	
```

I was able to fix these by making the following changes to `CustomShortcuts.uplugin` listed below:

```
Changed plugin dependency reference from EditorScriptingTools to EditorScriptingUtilities

Changed capitalization on like 23 from "Enabled": True to "Enabled": true
```

Figured I'd pass this info along, dunno if anyone else has had the same error but if so maybe this can help!

Cheers!

-Christian